### PR TITLE
Update syntax in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Basic usage:
 all items shall have the same height
 
 ```html
-<div *vsFor="items; #_items = vsCollection">
-    <div *ngFor="#item of _items">
+<div *vsFor="items; let _items = vsCollection">
+    <div *ngFor="item of _items">
         <!-- item html here -->
     </div>
 </div>

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ all items shall have the same height
 
 ```html
 <div *vsFor="items; let _items = vsCollection">
-    <div *ngFor="item of _items">
+    <div *ngFor="let item of _items">
         <!-- item html here -->
     </div>
 </div>
@@ -42,8 +42,8 @@ import {Component} from 'angular2/core';
     selector: 'some-component',
     directives: [VsFor],
     template: `
-        <div *vsFor="items; size:getSize; #_items = vsCollection">
-            <div *ngFor="#item of _items">
+        <div *vsFor="items; size:getSize; let _items = vsCollection">
+            <div *ngFor="let item of _items">
                 <!-- item html here -->
             </div>
         </div>

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ all items shall have the same height
 </div>
 ```
 
-Items have varoius sizes but they are known up front (calculatable based on their properties)
+Items have various sizes but they are known up front (calculatable based on their properties)
 
 ```javascript
 import {VsFor} from 'ng2-vs-for';


### PR DESCRIPTION
The use of `#` for local template variables within an `ngFor` has been deprecated from Beta 17. Ran into issues following the original syntax here.
